### PR TITLE
Fix adb command when id is set

### DIFF
--- a/index.js
+++ b/index.js
@@ -379,10 +379,10 @@ class ADBPlugin {
 							if(this.currentInputIndex != 0 && this.inputs[this.currentInputIndex].id != OTHER_APP_ID) {
 								let type = this.inputs[this.currentInputIndex].id.trim();
 
-								if(!type.includes(" ") && type.includes("."))
-									adb = `adb -s ${this.ip} shell "monkey -p ${this.inputs[this.currentInputIndex].id} 1"`;
-								else if (this.inputs[this.currentInputIndex].adb)
+								if (this.inputs[this.currentInputIndex].adb)
 									adb = `adb -s ${this.ip} shell "${this.inputs[this.currentInputIndex].adb}"`;
+								else if(!type.includes(" ") && type.includes("."))
+									adb = `adb -s ${this.ip} shell "monkey -p ${this.inputs[this.currentInputIndex].id} 1"`;
 								else
 									adb = `adb -s ${this.ip} shell "${this.inputs[this.currentInputIndex].id}"`;
 							}


### PR DESCRIPTION
As stated in the documentation, the `id` property in the `inputs` is mandatory. But looking at the code, setting `id` to the app id (eg. `com.google.android.youtube.tv`) will prevent the `adb` command from running. The first command `adb -s ${this.ip} shell "monkey -p ${this.inputs[this.currentInputIndex].id} 1"` should only run when there is no `adb` property configured. That's why I switched the if statements.

To give some examples, this works;
```json
{
    "name": "Youtube - Fireplace",
    "id": "1",
    "adb": "am start -a android.intent.action.VIEW -d vnd.youtube://www.youtube.com/watch?v=AWKzr6n0ea0"
}
```

while the below does not (because the check `!type.includes(" ") && type.includes(".")` will be true, the `adb` command never runs, it only opens the YouTube app)
```json
{
    "name": "Youtube - Fireplace",
    "id": "com.google.android.youtube.tv",
    "adb": "am start -a android.intent.action.VIEW -d vnd.youtube://www.youtube.com/watch?v=AWKzr6n0ea0"
}
```


I wouldn't have mind using the first example, but this results in the wrong `currentApp` being configured on [line 392](https://github.com/dwaan/homebridge-adb/blob/master/index.js#L392). Therefore I decided to create a PR.