### PR TITLE
correct command to display version

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This plugins register it self as external accesorries. Make sure after adding Ho
 	*  Or, if you're using other OS, please refer this link to download the ADB tools: [https://developer.android.com/studio/releases/platform-tools](https://developer.android.com/studio/releases/platform-tools)
 	*  Check if the ADB installed properly by running this command:
 		```
-		adb version
+		adb --version
 		```
 		This will output something like `Android Debug Bridge version x.x.x`
 


### PR DESCRIPTION
In setting this up, I ran `adb version` which printed `adb: unknown command version`.  That looks very much like the error when your shell can't find the executable in your path.  It took me more than a second to notice the error wasn't that `adb` wasn't found, it was that `adb` didn't know what to do with `version` as an argument.